### PR TITLE
Only define a single OID for composite objects

### DIFF
--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -33,7 +33,7 @@ author:
       email: mike.ounsworth@entrustdatacard.com
 
     -
-      ins: Max Pala (Editor)
+      ins: M. Pala (Editor)
       name: Massimiliano Pala
       org: CableLabs
       email: director@openca.org
@@ -68,7 +68,7 @@ informative:
 --- abstract
 With the widespread adoption of post-quantum cryptography will come the need for an entity to possess multiple public keys on different cryptographic algorithms. Since the trustworthiness of individual post-quantum algorithms is at question, a multi-key cryptographic operation will need to be performed in such a way that breaking it requires breaking each of the component algorithms individually. This requires defining new structures for holding composite public keys and composite signature data.
 
-This document defines the structures CompositePublicKey, CompositeSignatureAlgorithmParams, and CompositeSignatureValue which are sequences of the respective structure for each component algorithm. This document also defines algorithms for generating and verifying composite signatures. This document makes no assumptions about what the component algorithms are, provided that their algorithm identifiers and signature generation and verification algorithms are defined.
+This document defines the structures CompositePublicKey, CompositeSignatureValue, and CompositeParams, which are sequences of the respective structure for each component algorithm. This document also defines algorithms for generating and verifying composite signatures. This document makes no assumptions about what the component algorithms are, provided that their algorithm identifiers and signature generation and verification algorithms are defined.
 
 <!-- End of Abstract -->
 
@@ -119,8 +119,8 @@ COMPOSITE ALGORITHM:  An algorithm which is a sequence of one or
 
 DER:  Distinguished Encoding Rules as defined in [X.690].
 
-SIGNATURE:  ... digital cryptographic signature, making no assumptions
-            about which algorithm.
+SIGNATURE:  ... digital cryptographic signature, making no
+            assumptions about which algorithm.
 
 ~~~
 {: artwork-name="glossary"}
@@ -144,47 +144,60 @@ This section defines
 
 _EDNOTE: Defining composite algorithm parameters as a sequence inside the existing structure avoids an exponential proliferation of OIDs that are needed for each pairwise combination of signature algorithms in other competing schemes for achieving multi-key certificates. This scheme also naturally extends from 2-keypair to n-keypair keys and certificates._
 
+## Algorithm Identifier
 
-## Composite Public Key {#sec-composite-pub-keys}
-A composite public key is a sequence of component public keys that are used together.  A composite public key is identified by the object identifier
+The same algorithm identifier is used for identifying a public key, a private key, and a signature.  Additional encoding information is provided below for each of these objects.
 
 ~~~ asn.1
-id-ce-compositePublicKey OBJECT IDENTIFIER ::= { OID }
+id-Composite OBJECT IDENTIFIER ::= { TBD }
 ~~~
-{: artwork-name="CompositePublicKeyOID-asn.1-structures"}
 
-The parameters field for this public key type MUST be absent.  The composite public key data is represented by the following structure:
+## Composite Keys
+
+The ASN.1 algorithm object for composite public and private keys is:
 
 ~~~ asn.1
-CompositePublicKey ::= SEQUENCE OF SubjectPublicKeyInfo
+pk-Composite PUBLIC-KEY ::= {
+    IDENTIFIER id-Composite
+    KEY CompositePublicKey
+    PARAMS ARE absent
+    CERT-KEY-USAGE
+        { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
+    PRIVATE-KEY CompositePrivateKey
+}
+~~~
+{: artwork-name="CompositeAlgorithmObject-asn.1-structures"}
+
+## Composite Public Key
+
+A composite public key is a sequence of component public keys that are used together.  The AlgorithmIdentifier for a composite public key uses the id-Composite object identifier, and the parameters field MUST be absent.  A composite public key MUST contain at least one component public key.
+
+Each element of a CompositePublicKey is a SubjectPublicKeyInfo object for a component public key.  When the composite public key must be provided in octet string or bit string format, the data structure is converted as specified in {{sec-encoding-rules}}.
+
+The composite public key data is represented by the following structure:
+
+~~~ asn.1
+CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
 ~~~
 {: artwork-name="CompositePublicKey-asn.1-structures"}
 
-where each element of the sequence is a `SubjectPublicKeyInfo` of a component public key.  When the composite public key must be provided in octet string or bit string format, the data structure is converted as specified in {{sec-encoding-rules}}.
-
-
 ## Composite Private Key
 
-This section specifies a syntax and semantics for composite private key information. Composite private key information is built as a SEQUENCE of BIT STRINGs each of which contains the single private keys and parameters. Additionally, it may include the corresponding public keys.
+A composite private key is a sequence of component private keys that are used together.  The AlgorithmIdentifier for a composite private key uses the id-Composite object identifier, and the parameters field MUST be absent.  A composite private key MUST contain at least one component private key.
 
-The structure defined in this document allows for the distribution of the composite keys (public and private) and the associated domain parameters by using a sequence of OneAsymmetricKey as defined in [RFC5958].
-
-The Composite Private Key is identified by the object identifier
-
-~~~ asn.1
-id-ce-compositePrivateKey OBJECT IDENTIFIER ::= { OID }
-~~~
-{: artwork-name="CompositePrivateKeyOID-asn.1-structures"}
+Each element of a CompositePrivateKey is a OneAsymmetricKey [RFC5958] object for a component private key.  The component private key's OneAsymmetricKey object may optionally include the corresponding public key.
 
 The composite private key data is represented by the following structure:
 
+TODO: the previous version defined the CompositePrivateKey as a SEQUENCE of OneAsymmetricKey but also said that it is a SEQUENCE of BIT STRINGs.  This doesn't make sense unless the OneAsymmetricKey objects are wrapped as a BIT STRING (in which case we need to specify this and why).
+
 ~~~ asn.1
-CompositePrivateKey ::= SEQUENCE OF OneAsymmetricKey
+CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
 ~~~
 {: artwork-name="CompositePrivateKey-asn.1-structures"}
 
 ### Encrypted and Un-encrypted Local Storage
-The compositePrivateKey format as defined in the previous subsection can also be used for local storage of an unencrypted compositePrivateKeys binary object. The compositePrivateKeys can also be formatted in PEM format that uses the (".pem") file extension and which is encoded as the the Base64 encoding (see Section 4 of [RFC4648]), of the DER-encoded compositePrivateKey object with the following armour:
+The compositePrivateKey format as defined in the previous subsection can also be used for local storage of an unencrypted compositePrivateKeys binary object. The compositePrivateKey can also be formatted in PEM format that uses the (".pem") file extension and which is encoded as the the Base64 encoding (see Section 4 of [RFC4648]), of the DER-encoded compositePrivateKey object with the following armour:
 
 ~~~
 -----BEGIN COMPOSITE PRIVATE KEY-----
@@ -192,19 +205,19 @@ The compositePrivateKey format as defined in the previous subsection can also be
 ~~~
 {: artwork-name="privkey-pem-armour"}
 
-Local storage of an encrypted CompositePrivateKeys object is out of scope of this document.  However, CompositePrivateKeys should be the format for the plaintext key being encrypted.  DER encoding the CompositePrivateKeys will promote interoperability if the key is encrypted for transport to another party.  PEM encoding the DER-encoded CompositePrivateKeys is common; "Proc-Type:" and "DEK-INFO:" fields [RFC1421] followed by the DER-encoded CompositePrivateKeys.
+Local storage of an encrypted CompositePrivateKeys object is out of scope of this document.  However, CompositePrivateKey should be the format for the plaintext key being encrypted.  DER encoding the CompositePrivateKey will promote interoperability if the key is encrypted for transport to another party.  PEM encoding the DER-encoded CompositePrivateKey is common; "Proc-Type:" and "DEK-INFO:" fields [RFC1421] followed by the DER-encoded CompositePrivateKey.
 The following armour used in this case is as follows:
 
 ~~~
------BEGIN COMPOSITE PRIVATE KEY-----
------END COMPOSITE PRIVATE KEY-----
+-----BEGIN ENCRYPTED COMPOSITE PRIVATE KEY-----
+-----END ENCRYPTED COMPOSITE PRIVATE KEY-----
 ~~~
 
 ### Asymmetric Key Packages
 
 The Cryptographic Message Syntax (CMS), as defined in [RFC5652], can be used to digitally sign, digest, authenticate, or encrypt the asymmetric key format content type.
 
-When encoding composite private keys, the privateKeyAlgorithm in the OneAsymmetricKey SHALL be set to id-ce-compositePrivateKey.
+When encoding composite private keys, the privateKeyAlgorithm in the OneAsymmetricKey SHALL be set to id-Composite.
 
 The parameters of the privateKeyAlgorithm SHALL be a sequence of AlgorithmIdentifier objects, each of which are encoded according to the rules defined for each of the different keys in the composite private key.
 
@@ -215,34 +228,40 @@ The value of the the publicKey (if present) SHALL be set to the DER encoding of 
 The value of the attributes is encoded as usual.
 
 ## Composite Signature Algorithm {#sec-composite-sigs}
-The Composite Signature signature algorithm defined in {{sec-composite-signature-algorithm}} is identified by the following object identifier:
+
+The ASN.1 algorithm object for a composite signature is:
 
 ~~~ asn.1
-id-ce-compositeSignature OBJECT IDENTIFIER ::= { OID }
+sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
+    IDENTIFIER id-Composite
+    VALUE CompositeSignatureValue
+    PARAMS TYPE CompositeParams ARE required
+    PUBLIC-KEYS { pk-Composite }
+    SMIME-CAPS { IDENTIFIED BY id-Composite } }
+}
 ~~~
-{: artwork-name="CompositeSignature-asn.1-structures"}
 
-The following algorithm parameters MUST be included when this identifier is used:
+The id-Composite object identifier is used to identify when a signature has been created by a composite private key.
+
+The following algorithm parameters MUST be included when this identifier is used to identify a signature algorithm:
 
 ~~~ asn.1
-CompositeSignatureAlgorithmParams ::= SEQUENCE OF AlgorithmIdentifier
+CompositeParams ::= SEQUENCE SIZE (1..MAX) OF AlgorithmIdentifier
 ~~~
 {: artwork-name="CompositeSignatureParams-asn.1-structures"}
 
-When a composite signature is generated by a key with a CompositePublicKey, the signature's CompositeSignatureAlgorithmParams sequence MUST contain the same component algorithms listed in the same order as in the associated CompositePublicKey.
+When a composite signature is generated by a composite private key, the signature's CompositeParams sequence MUST contain the same component algorithms listed in the same order as in the associated CompositePrivateKey and CompositePublicKey.
 
-The Composite Signature algorithm output is the DER encoding of the following structure:
+The composite signature algorithm output is the DER encoding of the following structure:
 
 ~~~ asn.1
-id-ce-CompositeSignatureValue OBJECT IDENTIFIER ::= { OID }
-
-CompositeSignatureValue ::= SEQUENCE OF BIT STRING
+CompositeSignatureValue ::= SEQUENCE SIZE (1..MAX) OF BIT STRING
 ~~~
 {: artwork-name="composite-sig-asn.1"}
 
-Where each bit string within `CompositeSignatureValue` is a signature by one of the component signature algorithms.
+Where each component within a CompositeSignatureValue SEQUENCE is a BIT STRING wrapping a signature produced by one of the component signature algorithms.
 
-The choice of `SEQUENCE OF BIT STRING` rather than `BIT STRING` is so the type-length-value encoding can solve the problem of variable-length signature values. The signature's `CompositeSignatureValue` sequence MUST contain the same component algorithms listed in the same order as in the associated `CompositeSignatureAlgorithmParams`.
+The choice of `SEQUENCE SIZE (1..MAX) OF BIT STRING` is so the BIT STRING encoding can solve the problem of variable-length signature values. The signature's `CompositeSignatureValue` sequence MUST contain signatures by the same component algorithms listed in the same order as in the associated `CompositeParams`.
 
 ## Encoding Rules {#sec-encoding-rules}
 <!-- EDNOTE: Examples of how other specifications specify how a data structure is converted to a bit string can be found in RFC 2313, section 10.1.4, 3279 section 2.3.5, and RFC 4055, section 3.2. -->
@@ -304,8 +323,8 @@ Input:
      A    Composite Algorithm identifier
 
 Output:
-    Validity      "Valid signature" (true) if the composite signature is
-                  valid, "Invalid signature" (false) otherwise.
+    Validity      "Valid signature" (true) if the composite signature
+                  is valid, "Invalid signature" (false) otherwise.
 
 Signature Verification Procedure::
    1. Parse P, S, A into the component public keys, signatures,
@@ -314,8 +333,9 @@ Signature Verification Procedure::
       S1, S2, ..., Sn := Desequence( S )
       A1, A2, ..., An := Desequence( A )
 
-    If Error during Desequencing, or the three sequences have different
-    numbers of elements, then output "Invalid signature" and stop.
+    If Error during Desequencing, or the three sequences have
+    different numbers of elements, then output "Invalid signature"
+    and stop.
 
    2. Check policy to see whether A1, A2, ..., An constitutes a valid
         combination of algorithms.
@@ -344,8 +364,11 @@ Implementations SHOULD verify all recognized and supported algorithms, and outpu
 
 <!-- End of Composite Signature Algorithm section -->
 
+<!--
+_EDNOTE: DVG is removing this section because the OIDs are already defined above and in the ASN.1 Module section.
 # New Algorithm Identifiers
-_EDNOTE: This subsection will define the OIDs for the initial composite algorithm combinations we want to define. These are the OID that Section 10 will ask for IANA to assign._
+_EDNOTE: This subsection will define the OIDs for the initial composite algorithm combinations we want to define. These are the OID that {#sec-iana} will ask for IANA to assign._
+-->
 
 # In Practice {#sec-in-pract}
 _EDNOTE: This section will talk about practical issue of how these certificates will be used. For example it will talk about the size of these certs and cert chains. It will explain that if a cert in the chain is a Composite cert then the whole chain needs to be of Composite Certs. It will also explain that the root CA cert does not have to be of the same algorithms. The root cert SHOULD NOT be transferred in the authentication exchange to save transport overhead and thus it can be different than the intermediate and leaf certs. It will talk about overhead (size and processing). It will also discuss backwards compatibility. It could include a subsection about implementation considerations._
@@ -376,10 +399,7 @@ This section talks about how protocols like (D)TLS and IKEv2 are affected by thi
 <!-- End of Implications for existing standards section -->
 
 # IANA Considerations {#sec-iana}
-The CMS content type OID is registered in a DoD arc.  The ASN.1
-   module OID is TBD.  The id-ce-compositePublicKey, id-ce-compositePrivateKey, id-ce-compositeSignature, and id-ce-CompositeSignatureValue OIDs are to be assigned by IANA.  The authors
-   suggest to use the id-pkix arc for this usage.
-
+The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned by IANA.  The authors suggest to use the id-pkix arc for this usage.
 
 <!-- End of IANA Considerations section -->
 
@@ -406,6 +426,82 @@ This document deals only with signature keys. While the CompositePublicKey and C
 <!-- End of Security Considerations section -->
 
 # Appendices
+
+## ASN.1 Module
+
+~~~ asn.1
+
+<CODE STARTS>
+
+Composite-Signatures-2019
+  { TBD }
+
+DEFINITIONS IMPLICIT TAGS ::= BEGIN
+
+EXPORTS ALL;
+
+IMPORTS
+  PUBLIC-KEY, SIGNATURE-ALGORITHM
+    FROM AlgorithmInformation-2009  -- RFC 5912 [X509ASN1]
+      { iso(1) identified-organization(3) dod(6) internet(1)
+        security(5) mechanisms(5) pkix(7) id-mod(0)
+        id-mod-algorithmInformation-02(58) }
+
+  SubjectPublicKeyInfo
+    FROM PKIX1Explicit-2009
+      { iso(1) identified-organization(3) dod(6) internet(1)
+        security(5) mechanisms(5) pkix(7) id-mod(0)
+        id-mod-pkix1-explicit-02(51) }
+
+  OneAsymmetricKey
+    FROM AsymmetricKeyPackageModuleV1
+      { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1)
+        pkcs-9(9) smime(16) modules(0)
+        id-mod-asymmetricKeyPkgV1(50) } ;
+
+--
+-- Object Identifiers
+--
+
+id-Composite OBJECT IDENTIFIER ::= { TBD }
+
+--
+-- Public Key
+--
+
+pk-Composite PUBLIC-KEY ::= {
+    IDENTIFIER id-Composite
+    KEY CompositePublicKey
+    PARAMS ARE absent
+    CERT-KEY-USAGE
+        { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
+    PRIVATE-KEY CompositePrivateKey
+}
+
+CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
+
+CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
+
+--
+-- Signature Algorithm
+--
+
+sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
+    IDENTIFIER id-Composite
+    VALUE CompositeSignatureValue
+    PARAMS TYPE CompositeParams ARE required
+    PUBLIC-KEYS { pk-Composite }
+    SMIME-CAPS { IDENTIFIED BY id-Composite } }
+
+CompositeParams ::= SEQUENCE SIZE (1..MAX) OF AlgorithmIdentifier
+
+CompositeSignatureValue ::= SEQUENCE SIZE (1..MAX) OF BIT STRING
+
+END
+
+<CODE ENDS>
+
+~~~
 
 ## Intellectual Property Considerations
 

--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -149,7 +149,9 @@ _EDNOTE: Defining composite algorithm parameters as a sequence inside the existi
 The same algorithm identifier is used for identifying a public key, a private key, and a signature.  Additional encoding information is provided below for each of these objects.
 
 ~~~ asn.1
-id-Composite OBJECT IDENTIFIER ::= { TBD }
+id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+    dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
+    id-alg-composite(101) }
 ~~~
 
 ## Composite Keys

--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -172,7 +172,7 @@ pk-Composite PUBLIC-KEY ::= {
 
 A composite public key is a sequence of component public keys that are used together.  The AlgorithmIdentifier for a composite public key uses the id-Composite object identifier, and the parameters field MUST be absent.  A composite public key MUST contain at least one component public key.
 
-Each element of a CompositePublicKey is a SubjectPublicKeyInfo object for a component public key.  When the composite public key must be provided in octet string or bit string format, the data structure is converted as specified in {{sec-encoding-rules}}.
+Each element of a CompositePublicKey is a SubjectPublicKeyInfo object for a component public key.  When the CompositePublicKey must be provided in octet string or bit string format, the data structure is converted as specified in {{sec-encoding-rules}}.
 
 The composite public key data is represented by the following structure:
 
@@ -181,6 +181,35 @@ CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
 ~~~
 {: artwork-name="CompositePublicKey-asn.1-structures"}
 
+## Key Usage Bits
+
+The intended application for the key is indicated in the keyUsage certificate extension and defined in the CERT-KEY-USAGE field of pk-Composite.
+
+If the keyUsage extension is present in an end-entity certificate that indicates id-Composite, then the keyUsage extension MUST contain one or both of the following values:
+
+~~~
+    nonRepudiation; and
+    digitalSignature.
+~~~
+{: artwork-name="Cert-Key-Usage-1"}
+
+If the keyUsage extension is present in a certification authority certificate that indicates id-Composite, then the keyUsage extension MUST contain one or more of the following values:
+
+~~~
+    nonRepudiation;
+    digitalSignature;
+    keyCertSign; and
+    cRLSign.
+~~~
+{: artwork-name="Cert-Key-Usage-2"}
+
+_EDNOTE: BEGIN - This text is based on RFC 8410 (Ed25519 etc in X.509). It specifies a minimum required set of key usage bits to set, but doesn't preclude one from setting more.  On the other hand, the text for cms-hash-sig is below.  It is less explicit about which situations use the signature-related bits, but does preclude all other bits from being set.  Do we want to follow one or the other of these models?
+
+QUOTE:
+When this AlgorithmIdentifier appears in the SubjectPublicKeyInfo field of an X.509 certificate [RFC5280], the certificate key usage extension MAY contain digitalSignature, nonRepudiation, keyCertSign, and cRLSign; however, it MUST NOT contain other values.
+
+_EDNOTE: END
+
 ## Composite Private Key
 
 A composite private key is a sequence of component private keys that are used together.  The AlgorithmIdentifier for a composite private key uses the id-Composite object identifier, and the parameters field MUST be absent.  A composite private key MUST contain at least one component private key.
@@ -188,8 +217,6 @@ A composite private key is a sequence of component private keys that are used to
 Each element of a CompositePrivateKey is a OneAsymmetricKey [RFC5958] object for a component private key.  The component private key's OneAsymmetricKey object may optionally include the corresponding public key.
 
 The composite private key data is represented by the following structure:
-
-TODO: the previous version defined the CompositePrivateKey as a SEQUENCE of OneAsymmetricKey but also said that it is a SEQUENCE of BIT STRINGs.  This doesn't make sense unless the OneAsymmetricKey objects are wrapped as a BIT STRING (in which case we need to specify this and why).
 
 ~~~ asn.1
 CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
@@ -363,12 +390,6 @@ Implementations SHOULD verify all recognized and supported algorithms, and outpu
 
 
 <!-- End of Composite Signature Algorithm section -->
-
-<!--
-_EDNOTE: DVG is removing this section because the OIDs are already defined above and in the ASN.1 Module section.
-# New Algorithm Identifiers
-_EDNOTE: This subsection will define the OIDs for the initial composite algorithm combinations we want to define. These are the OID that {#sec-iana} will ask for IANA to assign._
--->
 
 # In Practice {#sec-in-pract}
 _EDNOTE: This section will talk about practical issue of how these certificates will be used. For example it will talk about the size of these certs and cert chains. It will explain that if a cert in the chain is a Composite cert then the whole chain needs to be of Composite Certs. It will also explain that the root CA cert does not have to be of the same algorithms. The root cert SHOULD NOT be transferred in the authentication exchange to save transport overhead and thus it can be different than the intermediate and leaf certs. It will talk about overhead (size and processing). It will also discuss backwards compatibility. It could include a subsection about implementation considerations._

--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -149,9 +149,9 @@ _EDNOTE: Defining composite algorithm parameters as a sequence inside the existi
 The same algorithm identifier is used for identifying a public key, a private key, and a signature.  Additional encoding information is provided below for each of these objects.
 
 ~~~ asn.1
-id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
-    dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
-    id-alg-composite(101) }
+id-Composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
+    dod(6) internet(1) private(4) enterprise(1) OpenCA(18227)
+    Algorithms(2) id-alg-composite(101) }
 ~~~
 
 ## Composite Keys
@@ -422,7 +422,13 @@ This section talks about how protocols like (D)TLS and IKEv2 are affected by thi
 <!-- End of Implications for existing standards section -->
 
 # IANA Considerations {#sec-iana}
-The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned by IANA.  The authors suggest to use the id-pkix arc for this usage.
+The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned by IANA.  The authors suggest to use the id-pkix arc for this usage:
+
+~~~
+id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+    dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
+    id-alg-composite(??) }
+~~~
 
 <!-- End of IANA Considerations section -->
 

--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -210,13 +210,6 @@ If the keyUsage extension is present in a certification authority certificate th
 ~~~
 {: artwork-name="Cert-Key-Usage-2"}
 
-_EDNOTE: BEGIN - This text is based on RFC 8410 (Ed25519 etc in X.509). It specifies a minimum required set of key usage bits to set, but doesn't preclude one from setting more.  On the other hand, the text for cms-hash-sig is below.  It is less explicit about which situations use the signature-related bits, but does preclude all other bits from being set.  Do we want to follow one or the other of these models?
-
-QUOTE:
-When this AlgorithmIdentifier appears in the SubjectPublicKeyInfo field of an X.509 certificate [RFC5280], the certificate key usage extension MAY contain digitalSignature, nonRepudiation, keyCertSign, and cRLSign; however, it MUST NOT contain other values.
-
-_EDNOTE: END
-
 ## Composite Private Key
 
 A composite private key is a sequence of component private keys that are used together.  The AlgorithmIdentifier for a composite private key uses the id-alg-composite object identifier, and the parameters field MUST be absent.  A composite private key MUST contain at least one component private key.

--- a/draft-ounsworth-pq-composite-sigs.mkd
+++ b/draft-ounsworth-pq-composite-sigs.mkd
@@ -149,10 +149,12 @@ _EDNOTE: Defining composite algorithm parameters as a sequence inside the existi
 The same algorithm identifier is used for identifying a public key, a private key, and a signature.  Additional encoding information is provided below for each of these objects.
 
 ~~~ asn.1
-id-Composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
+id-alg-composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
     dod(6) internet(1) private(4) enterprise(1) OpenCA(18227)
-    Algorithms(2) id-alg-composite(101) }
+    Algorithms(2) id-alg-composite(1) }
 ~~~
+
+EDNOTE: this is a temporary OID for the purposes of prototyping. We are requesting IANA to assign a permanent OID, see section {{sec-iana}}.
 
 ## Composite Keys
 
@@ -160,7 +162,7 @@ The ASN.1 algorithm object for composite public and private keys is:
 
 ~~~ asn.1
 pk-Composite PUBLIC-KEY ::= {
-    IDENTIFIER id-Composite
+    IDENTIFIER id-alg-composite
     KEY CompositePublicKey
     PARAMS ARE absent
     CERT-KEY-USAGE
@@ -195,7 +197,7 @@ If the keyUsage extension is present in an end-entity certificate that indicates
 ~~~
 {: artwork-name="Cert-Key-Usage-1"}
 
-If the keyUsage extension is present in a certification authority certificate that indicates id-Composite, then the keyUsage extension MUST contain one or more of the following values:
+If the keyUsage extension is present in a certification authority certificate that indicates id-alg-composite, then the keyUsage extension MUST contain one or more of the following values:
 
 ~~~
     nonRepudiation;
@@ -214,7 +216,7 @@ _EDNOTE: END
 
 ## Composite Private Key
 
-A composite private key is a sequence of component private keys that are used together.  The AlgorithmIdentifier for a composite private key uses the id-Composite object identifier, and the parameters field MUST be absent.  A composite private key MUST contain at least one component private key.
+A composite private key is a sequence of component private keys that are used together.  The AlgorithmIdentifier for a composite private key uses the id-alg-composite object identifier, and the parameters field MUST be absent.  A composite private key MUST contain at least one component private key.
 
 Each element of a CompositePrivateKey is a OneAsymmetricKey [RFC5958] object for a component private key.  The component private key's OneAsymmetricKey object may optionally include the corresponding public key.
 
@@ -246,7 +248,7 @@ The following armour used in this case is as follows:
 
 The Cryptographic Message Syntax (CMS), as defined in [RFC5652], can be used to digitally sign, digest, authenticate, or encrypt the asymmetric key format content type.
 
-When encoding composite private keys, the privateKeyAlgorithm in the OneAsymmetricKey SHALL be set to id-Composite.
+When encoding composite private keys, the privateKeyAlgorithm in the OneAsymmetricKey SHALL be set to id-alg-composite.
 
 The parameters of the privateKeyAlgorithm SHALL be a sequence of AlgorithmIdentifier objects, each of which are encoded according to the rules defined for each of the different keys in the composite private key.
 
@@ -262,7 +264,7 @@ The ASN.1 algorithm object for a composite signature is:
 
 ~~~ asn.1
 sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
-    IDENTIFIER id-Composite
+    IDENTIFIER id-alg-composite
     VALUE CompositeSignatureValue
     PARAMS TYPE CompositeParams ARE required
     PUBLIC-KEYS { pk-Composite }
@@ -270,7 +272,7 @@ sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
 }
 ~~~
 
-The id-Composite object identifier is used to identify when a signature has been created by a composite private key.
+The id-alg-composite object identifier is used to identify when a signature has been created by a composite private key.
 
 The following algorithm parameters MUST be included when this identifier is used to identify a signature algorithm:
 
@@ -422,12 +424,12 @@ This section talks about how protocols like (D)TLS and IKEv2 are affected by thi
 <!-- End of Implications for existing standards section -->
 
 # IANA Considerations {#sec-iana}
-The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned by IANA.  The authors suggest to use the id-pkix arc for this usage:
+The ASN.1 module OID is TBD.  The id-alg-composite OID is to be assigned by IANA.  The authors suggest to use the id-pkix arc for this usage:
 
 ~~~
-id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+id-alg-composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
     dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
-    id-alg-composite(??) }
+    composite(??) }
 ~~~
 
 <!-- End of IANA Considerations section -->

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -4,9 +4,9 @@
 
 LAMPS                                              M. Ounsworth (Editor)
 Internet-Draft                                          Entrust Datacard
-Intended status: Standards Track                     . Max Pala (Editor)
-Expires: December 1, 2019                                      CableLabs
-                                                            May 30, 2019
+Intended status: Standards Track                        M. Pala (Editor)
+Expires: December 7, 2019                                      CableLabs
+                                                           June 05, 2019
 
 
          Composite Keys and Signatures For Use In Internet PKI
@@ -24,13 +24,12 @@ Abstract
    keys and composite signature data.
 
    This document defines the structures CompositePublicKey,
-   CompositeSignatureAlgorithmParams, and CompositeSignatureValue which
-   are sequences of the respective structure for each component
-   algorithm.  This document also defines algorithms for generating and
-   verifying composite signatures.  This document makes no assumptions
-   about what the component algorithms are, provided that their
-   algorithm identifiers and signature generation and verification
-   algorithms are defined.
+   CompositeSignatureValue, and CompositeParams, which are sequences of
+   the respective structure for each component algorithm.  This document
+   also defines algorithms for generating and verifying composite
+   signatures.  This document makes no assumptions about what the
+   component algorithms are, provided that their algorithm identifiers
+   and signature generation and verification algorithms are defined.
 
 Status of This Memo
 
@@ -47,15 +46,16 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 1, 2019.
+   This Internet-Draft will expire on December 7, 2019.
 
 
 
 
 
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 1]
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 1]
 
-Internet-Draft             PQ Composite Certs                   May 2019
+Internet-Draft             PQ Composite Certs                  June 2019
 
 
 Copyright Notice
@@ -79,44 +79,46 @@ Table of Contents
      1.1.  Conventions and Terminology . . . . . . . . . . . . . . .   4
      1.2.  Notation  . . . . . . . . . . . . . . . . . . . . . . . .   4
    2.  Composite Structures  . . . . . . . . . . . . . . . . . . . .   5
-     2.1.  Composite Public Key  . . . . . . . . . . . . . . . . . .   5
-     2.2.  Composite Private Key . . . . . . . . . . . . . . . . . .   6
-       2.2.1.  Encrypted and Un-encrypted Local Storage  . . . . . .   6
-       2.2.2.  Asymmetric Key Packages . . . . . . . . . . . . . . .   7
-     2.3.  Composite Signature Algorithm . . . . . . . . . . . . . .   7
-     2.4.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   8
-   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .   8
+     2.1.  Algorithm Identifier  . . . . . . . . . . . . . . . . . .   5
+     2.2.  Composite Keys  . . . . . . . . . . . . . . . . . . . . .   5
+     2.3.  Composite Public Key  . . . . . . . . . . . . . . . . . .   6
+     2.4.  Composite Private Key . . . . . . . . . . . . . . . . . .   6
+       2.4.1.  Encrypted and Un-encrypted Local Storage  . . . . . .   7
+       2.4.2.  Asymmetric Key Packages . . . . . . . . . . . . . . .   7
+     2.5.  Composite Signature Algorithm . . . . . . . . . . . . . .   8
+     2.6.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   9
+   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .   9
      3.1.  Composite Signature Generation  . . . . . . . . . . . . .   9
-     3.2.  Composite Signature Verification  . . . . . . . . . . . .   9
-   4.  New Algorithm Identifiers . . . . . . . . . . . . . . . . . .  11
-   5.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  11
-   6.  Implications for existing standards . . . . . . . . . . . . .  11
-     6.1.  RFC 2986  . . . . . . . . . . . . . . . . . . . . . . . .  11
-     6.2.  RFC 5280  . . . . . . . . . . . . . . . . . . . . . . . .  11
-     6.3.  Cryptographic protocols . . . . . . . . . . . . . . . . .  11
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
-     8.1.  Protection of Private Keys  . . . . . . . . . . . . . . .  12
-     8.2.  Checking for Compromised Key Reuse  . . . . . . . . . . .  13
-     8.3.  Composite Encryption and KEMs . . . . . . . . . . . . . .  13
-   9.  Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  13
-     9.1.  Intellectual Property Considerations  . . . . . . . . . .  13
-     9.2.  Other ideas that were considered  . . . . . . . . . . . .  13
-       9.2.1.  Mechanisms to distribute verification policy to
-               clients . . . . . . . . . . . . . . . . . . . . . . .  13
-   10. Contributors and Acknowledgements . . . . . . . . . . . . . .  17
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  17
+     3.2.  Composite Signature Verification  . . . . . . . . . . . .  10
+   4.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  12
+   5.  Implications for existing standards . . . . . . . . . . . . .  12
+     5.1.  RFC 2986  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     5.2.  RFC 5280  . . . . . . . . . . . . . . . . . . . . . . . .  12
+     5.3.  Cryptographic protocols . . . . . . . . . . . . . . . . .  12
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
+     7.1.  Protection of Private Keys  . . . . . . . . . . . . . . .  13
+     7.2.  Checking for Compromised Key Reuse  . . . . . . . . . . .  13
+     7.3.  Composite Encryption and KEMs . . . . . . . . . . . . . .  13
+   8.  Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+     8.1.  ASN.1 Module  . . . . . . . . . . . . . . . . . . . . . .  14
+     8.2.  Intellectual Property Considerations  . . . . . . . . . .  15
+     8.3.  Other ideas that were considered  . . . . . . . . . . . .  15
+       8.3.1.  Mechanisms to distribute verification policy to
+               clients . . . . . . . . . . . . . . . . . . . . . . .  15
 
 
 
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 2]
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 2]
 
-Internet-Draft             PQ Composite Certs                   May 2019
+Internet-Draft             PQ Composite Certs                  June 2019
 
 
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  17
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  18
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
+   9.  Contributors and Acknowledgements . . . . . . . . . . . . . .  19
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  19
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  19
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  20
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  21
 
 1.  Introduction
 
@@ -160,16 +162,16 @@ Internet-Draft             PQ Composite Certs                   May 2019
    signatures, we note that the same structure is equally applicable to
    asymmetric encryption keys.  Though a word of warning that the
    corresponding "encrypt / decrypt with a composite public key" logic
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 3]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    is somewhat less obvious; a naive implementer might be tempted to
    follow the same pattern as below and encrypt the message with each
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 3]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
    public key separately and then concatenate the ciphertexts, which is
    wrong, they need to be nested.  Specifying the correct implementation
    of such an encryption scheme is out of scope for this document, but
@@ -181,7 +183,7 @@ Internet-Draft             PQ Composite Certs                   May 2019
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in BCP
-   14 [RFC2119]  [RFC8174] when, and only when, they appear in all
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
    capitals, as shown here.
 
    The following terms are used:
@@ -189,25 +191,25 @@ Internet-Draft             PQ Composite Certs                   May 2019
    _EDNOTE: A glossary of terms we define for this document, or terms
    that we borrow from other RFCs._
 
-  ALGORITHM: An information object class for identifying the type of
-              cryptographic operation to be performed. This document is
-              primarily concerned with algorithms for producing digital
-              signatures, though the public key structure could just as
-              easily hold encryption keys.
+   ALGORITHM: An information object class for identifying the type of
+               cryptographic operation to be performed. This document is
+               primarily concerned with algorithms for producing digital
+               signatures, though the public key structure could just as
+               easily hold encryption keys.
 
-  BER:  Basic Encoding Rules (BER) as defined in [X.690].
+   BER:  Basic Encoding Rules (BER) as defined in [X.690].
 
-  COMPONENT ALGORITHM:  A single basic algorithm which is contained
-                        within a composite algorithm.
+   COMPONENT ALGORITHM:  A single basic algorithm which is contained
+                         within a composite algorithm.
 
-  COMPOSITE ALGORITHM:  An algorithm which is a sequence of one or
-                        more basic algorithm, as defined in
-                        {{sec-composite-structs}}.
+   COMPOSITE ALGORITHM:  An algorithm which is a sequence of one or
+                         more basic algorithm, as defined in
+                         {{sec-composite-structs}}.
 
-  DER:  Distinguished Encoding Rules as defined in [X.690].
+   DER:  Distinguished Encoding Rules as defined in [X.690].
 
-  SIGNATURE:  ... digital cryptographic signature, making no assumptions
-              about which algorithm.
+   SIGNATURE:  ... digital cryptographic signature, making no
+               assumptions about which algorithm.
 
 
 1.2.  Notation
@@ -219,11 +221,9 @@ Internet-Draft             PQ Composite Certs                   May 2019
 
 
 
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 4]
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 4]
 
-Internet-Draft             PQ Composite Certs                   May 2019
+Internet-Draft             PQ Composite Certs                  June 2019
 
 
 2.  Composite Structures
@@ -258,62 +258,95 @@ Internet-Draft             PQ Composite Certs                   May 2019
    This scheme also naturally extends from 2-keypair to n-keypair keys
    and certificates._
 
-2.1.  Composite Public Key
+2.1.  Algorithm Identifier
+
+   The same algorithm identifier is used for identifying a public key, a
+   private key, and a signature.  Additional encoding information is
+   provided below for each of these objects.
+
+   id-Composite OBJECT IDENTIFIER ::= { TBD }
+
+2.2.  Composite Keys
+
+   The ASN.1 algorithm object for composite public and private keys is:
+
+
+
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 5]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+   pk-Composite PUBLIC-KEY ::= {
+       IDENTIFIER id-Composite
+       KEY CompositePublicKey
+       PARAMS ARE absent
+       CERT-KEY-USAGE
+           { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
+       PRIVATE-KEY CompositePrivateKey
+   }
+
+2.3.  Composite Public Key
 
    A composite public key is a sequence of component public keys that
-   are used together.  A composite public key is identified by the
-   object identifier
+   are used together.  The AlgorithmIdentifier for a composite public
+   key uses the id-Composite object identifier, and the parameters field
+   MUST be absent.  A composite public key MUST contain at least one
+   component public key.
 
-   id-ce-compositePublicKey OBJECT IDENTIFIER ::= { OID }
+   Each element of a CompositePublicKey is a SubjectPublicKeyInfo object
+   for a component public key.  When the composite public key must be
+   provided in octet string or bit string format, the data structure is
+   converted as specified in Section 2.6.
 
-   The parameters field for this public key type MUST be absent.  The
-   composite public key data is represented by the following structure:
+   The composite public key data is represented by the following
+   structure:
 
-   CompositePublicKey ::= SEQUENCE OF SubjectPublicKeyInfo
+   CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
 
-   where each element of the sequence is a "SubjectPublicKeyInfo" of a
-   component public key.  When the composite public key must be provided
+2.4.  Composite Private Key
 
+   A composite private key is a sequence of component private keys that
+   are used together.  The AlgorithmIdentifier for a composite private
+   key uses the id-Composite object identifier, and the parameters field
+   MUST be absent.  A composite private key MUST contain at least one
+   component private key.
 
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 5]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-   in octet string or bit string format, the data structure is converted
-   as specified in Section 2.4.
-
-2.2.  Composite Private Key
-
-   This section specifies a syntax and semantics for composite private
-   key information.  Composite private key information is built as a
-   SEQUENCE of BIT STRINGs each of which contains the single private
-   keys and parameters.  Additionally, it may include the corresponding
-   public keys.
-
-   The structure defined in this document allows for the distribution of
-   the composite keys (public and private) and the associated domain
-   parameters by using a sequence of OneAsymmetricKey as defined in
-   [RFC5958].
-
-   The Composite Private Key is identified by the object identifier
-
-   id-ce-compositePrivateKey OBJECT IDENTIFIER ::= { OID }
+   Each element of a CompositePrivateKey is a OneAsymmetricKey [RFC5958]
+   object for a component private key.  The component private key's
+   OneAsymmetricKey object may optionally include the corresponding
+   public key.
 
    The composite private key data is represented by the following
    structure:
 
-   CompositePrivateKey ::= SEQUENCE OF OneAsymmetricKey
+   TODO: the previous version defined the CompositePrivateKey as a
+   SEQUENCE of OneAsymmetricKey but also said that it is a SEQUENCE of
+   BIT STRINGs.  This doesn't make sense unless the OneAsymmetricKey
+   objects are wrapped as a BIT STRING (in which case we need to specify
+   this and why).
 
-2.2.1.  Encrypted and Un-encrypted Local Storage
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 6]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+   CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
+
+2.4.1.  Encrypted and Un-encrypted Local Storage
 
    The compositePrivateKey format as defined in the previous subsection
    can also be used for local storage of an unencrypted
-   compositePrivateKeys binary object.  The compositePrivateKeys can
-   also be formatted in PEM format that uses the (".pem") file extension
-   and which is encoded as the the Base64 encoding (see Section 4 of
+   compositePrivateKeys binary object.  The compositePrivateKey can also
+   be formatted in PEM format that uses the (".pem") file extension and
+   which is encoded as the the Base64 encoding (see Section 4 of
    [RFC4648]), of the DER-encoded compositePrivateKey object with the
    following armour:
 
@@ -321,34 +354,25 @@ Internet-Draft             PQ Composite Certs                   May 2019
    -----END COMPOSITE PRIVATE KEY-----
 
    Local storage of an encrypted CompositePrivateKeys object is out of
-   scope of this document.  However, CompositePrivateKeys should be the
+   scope of this document.  However, CompositePrivateKey should be the
    format for the plaintext key being encrypted.  DER encoding the
-   CompositePrivateKeys will promote interoperability if the key is
+   CompositePrivateKey will promote interoperability if the key is
    encrypted for transport to another party.  PEM encoding the DER-
-   encoded CompositePrivateKeys is common; "Proc-Type:" and "DEK-INFO:"
-   fields [RFC1421] followed by the DER-encoded CompositePrivateKeys.
+   encoded CompositePrivateKey is common; "Proc-Type:" and "DEK-INFO:"
+   fields [RFC1421] followed by the DER-encoded CompositePrivateKey.
    The following armour used in this case is as follows:
 
+   -----BEGIN ENCRYPTED COMPOSITE PRIVATE KEY-----
+   -----END ENCRYPTED COMPOSITE PRIVATE KEY-----
 
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 6]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-   -----BEGIN COMPOSITE PRIVATE KEY-----
-   -----END COMPOSITE PRIVATE KEY-----
-
-2.2.2.  Asymmetric Key Packages
+2.4.2.  Asymmetric Key Packages
 
    The Cryptographic Message Syntax (CMS), as defined in [RFC5652], can
    be used to digitally sign, digest, authenticate, or encrypt the
    asymmetric key format content type.
 
    When encoding composite private keys, the privateKeyAlgorithm in the
-   OneAsymmetricKey SHALL be set to id-ce-compositePrivateKey.
+   OneAsymmetricKey SHALL be set to id-Composite.
 
    The parameters of the privateKeyAlgorithm SHALL be a sequence of
    AlgorithmIdentifier objects, each of which are encoded according to
@@ -361,6 +385,15 @@ Internet-Draft             PQ Composite Certs                   May 2019
    sequence SHALL be the same as identified in the sequence of
    parameters in the privateKeyAlgorithm.
 
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 7]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    The value of the the publicKey (if present) SHALL be set to the DER
    encoding of the SEQUENCE of publicKey values.  If this field is
    present, the number and order of elements SHALL be the same as
@@ -368,49 +401,56 @@ Internet-Draft             PQ Composite Certs                   May 2019
 
    The value of the attributes is encoded as usual.
 
-2.3.  Composite Signature Algorithm
+2.5.  Composite Signature Algorithm
 
-   The Composite Signature signature algorithm defined in Section 3 is
-   identified by the following object identifier:
+   The ASN.1 algorithm object for a composite signature is:
 
-   id-ce-compositeSignature OBJECT IDENTIFIER ::= { OID }
+   sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
+       IDENTIFIER id-Composite
+       VALUE CompositeSignatureValue
+       PARAMS TYPE CompositeParams ARE required
+       PUBLIC-KEYS { pk-Composite }
+       SMIME-CAPS { IDENTIFIED BY id-Composite } }
+   }
+
+   The id-Composite object identifier is used to identify when a
+   signature has been created by a composite private key.
 
    The following algorithm parameters MUST be included when this
-   identifier is used:
+   identifier is used to identify a signature algorithm:
 
-   CompositeSignatureAlgorithmParams ::= SEQUENCE OF AlgorithmIdentifier
+   CompositeParams ::= SEQUENCE SIZE (1..MAX) OF AlgorithmIdentifier
 
-   When a composite signature is generated by a key with a
-   CompositePublicKey, the signature's CompositeSignatureAlgorithmParams
-   sequence MUST contain the same component algorithms listed in the
-   same order as in the associated CompositePublicKey.
+   When a composite signature is generated by a composite private key,
+   the signature's CompositeParams sequence MUST contain the same
+   component algorithms listed in the same order as in the associated
+   CompositePrivateKey and CompositePublicKey.
 
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 7]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-   The Composite Signature algorithm output is the DER encoding of the
+   The composite signature algorithm output is the DER encoding of the
    following structure:
 
-   id-ce-CompositeSignatureValue OBJECT IDENTIFIER ::= { OID }
+   CompositeSignatureValue ::= SEQUENCE SIZE (1..MAX) OF BIT STRING
 
-   CompositeSignatureValue ::= SEQUENCE OF BIT STRING
+   Where each component within a CompositeSignatureValue SEQUENCE is a
+   BIT STRING wrapping a signature produced by one of the component
+   signature algorithms.
 
-   Where each bit string within "CompositeSignatureValue" is a signature
-   by one of the component signature algorithms.
+   The choice of "SEQUENCE SIZE (1..MAX) OF BIT STRING" is so the BIT
+   STRING encoding can solve the problem of variable-length signature
+   values.  The signature's "CompositeSignatureValue" sequence MUST
+   contain signatures by the same component algorithms listed in the
+   same order as in the associated "CompositeParams".
 
-   The choice of "SEQUENCE OF BIT STRING" rather than "BIT STRING" is so
-   the type-length-value encoding can solve the problem of variable-
-   length signature values.  The signature's "CompositeSignatureValue"
-   sequence MUST contain the same component algorithms listed in the
-   same order as in the associated "CompositeSignatureAlgorithmParams".
 
-2.4.  Encoding Rules
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 8]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+2.6.  Encoding Rules
 
    Many specifications require that the composite public key and
    composite signature data structures be represented by an octet string
@@ -441,19 +481,30 @@ Internet-Draft             PQ Composite Certs                   May 2019
    breaking the composite signature would require breaking each of the
    component signatures.
 
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 8]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
 3.1.  Composite Signature Generation
 
    The following algorithm is used to generate composite signature
    values.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 9]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    Input:
         K1, K2, ..., Kn    Private keys for the n component signature
@@ -494,58 +545,59 @@ Internet-Draft             PQ Composite Certs                   May 2019
    for this document, but this document notes that at least one
    component signature MUST be verified.
 
-   EDNOTE: See the appendix Section 9.2.1 for further discussion of
+   EDNOTE: See the appendix Section 8.3.1 for further discussion of
    possible standardization of such mechanisms.
-
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019                [Page 9]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
 
    This section provides a sample algorithm for validating composite
    signatures.  Compliant implementations MUST return "Invalid
    signature" whenever the sample algorithm does, with the exception of
    the modification noted below.
 
-Input:
-     P    Signer's composite public key
-     M    Message whose signature is to be verified, an octet string
-     S    Composite Signature to be verified
-     A    Composite Algorithm identifier
 
-Output:
-    Validity      "Valid signature" (true) if the composite signature is
-                  valid, "Invalid signature" (false) otherwise.
 
-Signature Verification Procedure::
-   1. Parse P, S, A into the component public keys, signatures,
-      algorithm identifiers
-      P1, P2, ..., Pn := Desequence( P )
-      S1, S2, ..., Sn := Desequence( S )
-      A1, A2, ..., An := Desequence( A )
 
-    If Error during Desequencing, or the three sequences have different
-    numbers of elements, then output "Invalid signature" and stop.
 
-   2. Check policy to see whether A1, A2, ..., An constitutes a valid
-        combination of algorithms.
-     if not checkPolicy(A1, A2, ..., An), then
-       output "Invalid signature"
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 10]
+
+Internet-Draft             PQ Composite Certs                  June 2019
 
-   3. Check each component signature individually. If any fail, then
-        the entire signature validation fails
-     for i := 1 to n
-        Verify the component signature according to the component
-        algorithm's specification
-          if not verify( Pi, M, Si ), then
-            output "Invalid signature"
 
-      if all succeeded, then
-        output "Valid signature"
+   Input:
+        P    Signer's composite public key
+        M    Message whose signature is to be verified, an octet string
+        S    Composite Signature to be verified
+        A    Composite Algorithm identifier
+
+   Output:
+       Validity      "Valid signature" (true) if the composite signature
+                     is valid, "Invalid signature" (false) otherwise.
+
+   Signature Verification Procedure::
+      1. Parse P, S, A into the component public keys, signatures,
+         algorithm identifiers
+         P1, P2, ..., Pn := Desequence( P )
+         S1, S2, ..., Sn := Desequence( S )
+         A1, A2, ..., An := Desequence( A )
+
+       If Error during Desequencing, or the three sequences have
+       different numbers of elements, then output "Invalid signature"
+       and stop.
+
+      2. Check policy to see whether A1, A2, ..., An constitutes a valid
+           combination of algorithms.
+        if not checkPolicy(A1, A2, ..., An), then
+          output "Invalid signature"
+
+      3. Check each component signature individually. If any fail, then
+           the entire signature validation fails
+        for i := 1 to n
+           Verify the component signature according to the component
+           algorithm's specification
+             if not verify( Pi, M, Si ), then
+               output "Invalid signature"
+
+         if all succeeded, then
+           output "Valid signature"
 
 
 
@@ -554,31 +606,24 @@ Signature Verification Procedure::
    or where the performance gains from omitting algorithms justifies the
    loss of security.  In these cases, an acceptable modification to this
    algorithm is to produce in step 2 one or more subsets of the
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 10]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
    algorithms "A1, A2, ..., An" which constitute acceptable
    combinations, outputting "Invalid signature" if an acceptable subset
    can not be found, and then in step 3 only perform verification of the
    necessary component algorithms.
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 11]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    Implementations SHOULD verify all recognized and supported
    algorithms, and output "Invalid signature" if the verification of any
    component signature fails, but MAY choose to only verify a subset of
    the algorithms for the reasons stated above.
 
-4.  New Algorithm Identifiers
-
-   _EDNOTE: This subsection will define the OIDs for the initial
-   composite algorithm combinations we want to define.  These are the
-   OID that Section 10 will ask for IANA to assign._
-
-5.  In Practice
+4.  In Practice
 
    _EDNOTE: This section will talk about practical issue of how these
    certificates will be used.  For example it will talk about the size
@@ -592,31 +637,23 @@ Internet-Draft             PQ Composite Certs                   May 2019
    discuss backwards compatibility.  It could include a subsection about
    implementation considerations._
 
-6.  Implications for existing standards
+5.  Implications for existing standards
 
-6.1.  RFC 2986
+5.1.  RFC 2986
 
    _EDNOTE: summarize the updates to RFC 2986 (CSR / PKCS#10)._
 
-6.2.  RFC 5280
+5.2.  RFC 5280
 
    _EDNOTE: summarize the updates to RFC 5280 (X.509)._
 
-6.3.  Cryptographic protocols
+5.3.  Cryptographic protocols
 
    This section talks about how protocols like (D)TLS and IKEv2 are
    affected by this specifications.  It will not attempt to solve all
    these problems, but it will explain the rationale, how things will
    work and what open problems need to be solved.  Obvious issues that
    need to be discussed.
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 11]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
 
    o  How does the protocol declare support for composite signatures?
       TLS has hooks for declaring support for specific signature
@@ -629,6 +666,14 @@ Internet-Draft             PQ Composite Certs                   May 2019
       would be to have the server sign using its composite public key;
       is this sufficient.
 
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 12]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    o  Overhead; including certificate size, signature processing time,
       and size of the signature.
 
@@ -638,17 +683,14 @@ Internet-Draft             PQ Composite Certs                   May 2019
       encoding composite ciphertexts is less so - we decided to put that
       off to another draft.
 
-7.  IANA Considerations
+6.  IANA Considerations
 
-   The CMS content type OID is registered in a DoD arc.  The ASN.1
-   module OID is TBD.  The id-ce-compositePublicKey, id-ce-
-   compositePrivateKey, id-ce-compositeSignature, and id-ce-
-   CompositeSignatureValue OIDs are to be assigned by IANA.  The authors
-   suggest to use the id-pkix arc for this usage.
+   The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned
+   by IANA.  The authors suggest to use the id-pkix arc for this usage.
 
-8.  Security Considerations
+7.  Security Considerations
 
-8.1.  Protection of Private Keys
+7.1.  Protection of Private Keys
 
    This structures described in this document do not protect the private
    keys information in any way unless combined with a security protocol
@@ -663,25 +705,14 @@ Internet-Draft             PQ Composite Certs                   May 2019
    the managed keying material.  The encryption algorithm used in the
    encryption process must be as 'strong' as the key it is protecting.
 
-
-
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 12]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-8.2.  Checking for Compromised Key Reuse
+7.2.  Checking for Compromised Key Reuse
 
    CA implementations need to be careful when checking for compromised
    key reuse, for example as required by WebTrust regulations; when
    checking for compromised keys, you MUST unpack the CompositePublicKey
    structure and compare individual component keys.
 
-8.3.  Composite Encryption and KEMs
+7.3.  Composite Encryption and KEMs
 
    This document deals only with signature keys.  While the
    CompositePublicKey and CompositePrivateKey structures could equally
@@ -692,9 +723,97 @@ Internet-Draft             PQ Composite Certs                   May 2019
    in a catastrophic loss of security.  We leave it to the community to
    standardize analogous composite encryption and KEM schemes.
 
-9.  Appendices
 
-9.1.  Intellectual Property Considerations
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 13]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+8.  Appendices
+
+8.1.  ASN.1 Module
+
+   <CODE STARTS>
+
+   Composite-Signatures-2019
+     { TBD }
+
+   DEFINITIONS IMPLICIT TAGS ::= BEGIN
+
+   EXPORTS ALL;
+
+   IMPORTS
+     PUBLIC-KEY, SIGNATURE-ALGORITHM
+       FROM AlgorithmInformation-2009  -- RFC 5912 [X509ASN1]
+         { iso(1) identified-organization(3) dod(6) internet(1)
+           security(5) mechanisms(5) pkix(7) id-mod(0)
+           id-mod-algorithmInformation-02(58) }
+
+     SubjectPublicKeyInfo
+       FROM PKIX1Explicit-2009
+         { iso(1) identified-organization(3) dod(6) internet(1)
+           security(5) mechanisms(5) pkix(7) id-mod(0)
+           id-mod-pkix1-explicit-02(51) }
+
+     OneAsymmetricKey
+       FROM AsymmetricKeyPackageModuleV1
+         { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1)
+           pkcs-9(9) smime(16) modules(0)
+           id-mod-asymmetricKeyPkgV1(50) } ;
+
+   --
+   -- Object Identifiers
+   --
+
+   id-Composite OBJECT IDENTIFIER ::= { TBD }
+
+   --
+   -- Public Key
+   --
+
+   pk-Composite PUBLIC-KEY ::= {
+       IDENTIFIER id-Composite
+       KEY CompositePublicKey
+       PARAMS ARE absent
+       CERT-KEY-USAGE
+           { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 14]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+       PRIVATE-KEY CompositePrivateKey
+   }
+
+   CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
+
+   CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
+
+   --
+   -- Signature Algorithm
+   --
+
+   sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
+       IDENTIFIER id-Composite
+       VALUE CompositeSignatureValue
+       PARAMS TYPE CompositeParams ARE required
+       PUBLIC-KEYS { pk-Composite }
+       SMIME-CAPS { IDENTIFIED BY id-Composite } }
+
+   CompositeParams ::= SEQUENCE SIZE (1..MAX) OF AlgorithmIdentifier
+
+   CompositeSignatureValue ::= SEQUENCE SIZE (1..MAX) OF BIT STRING
+
+   END
+
+   <CODE ENDS>
+
+
+8.2.  Intellectual Property Considerations
 
    The authors are aware that Massimiliano Pala and CableLabs hold
    Intellectual Property around composite key, signatures, and
@@ -704,17 +823,25 @@ Internet-Draft             PQ Composite Certs                   May 2019
    However, at time of writing, this is all verbal hearsay; we have yet
    to find any written documentation of the existence of the IPR.
 
-9.2.  Other ideas that were considered
+8.3.  Other ideas that were considered
 
    This section is here to be informative during the review process, to
    document ideas that were raised and the rationales for not including
    them in the final draft.
 
-9.2.1.  Mechanisms to distribute verification policy to clients
+8.3.1.  Mechanisms to distribute verification policy to clients
 
    EDNOTE: The authors had extensive discussions about how to handle
    algorithm revocation / deprication, sepcifically around how to
    distribute policy information to verifiers.  In the end we decided to
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 15]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    remove the whole thing and instead leave this is a responsibility of
    the implementors of the software performing signature verification.
 
@@ -722,13 +849,6 @@ Internet-Draft             PQ Composite Certs                   May 2019
    sake, but should be removed in a subsequent version of this draft.
 
    -
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 13]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
 
    In the traditional world of single-key public keys and signatures,
    the semantics of a signature and a verification are straight-forward:
@@ -757,13 +877,13 @@ Internet-Draft             PQ Composite Certs                   May 2019
    that algorithm.  However, we are not sure if the gains justify the
    added complexity.
 
-9.2.1.1.  Local verifier policy
+8.3.1.1.  Local verifier policy
 
    Much as we do today, this is left up to domain administrators and
    software vendors to implement the guidance of governing bodies on a
    system-by-system basis.
 
-9.2.1.2.  Extra metadata in the public key or signature
+8.3.1.2.  Extra metadata in the public key or signature
 
    This policy information could be specified by the signer at signing
    time.  Depending on the structure of the databeing signed, this
@@ -771,22 +891,21 @@ Internet-Draft             PQ Composite Certs                   May 2019
    signature, or some other field provided that it is inside the signed
    data blob.
 
-9.2.1.3.  Extra metadata in the certificate
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 16]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+8.3.1.3.  Extra metadata in the certificate
 
    This policy information could be included in a certificate via an
    X.509 v3 extension.  This gives the Certificate Authority control,
    but has the drawback that updating the policy requires revoking and
    reissuing certificates.
 
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 14]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-9.2.1.4.  Policy certificate issued by the Certificate Authority
+8.3.1.4.  Policy certificate issued by the Certificate Authority
 
    Certificate Authorities have the ability to issue policy certificates
    that specify the behaviour when verifying signatures performed by
@@ -797,12 +916,12 @@ Internet-Draft             PQ Composite Certs                   May 2019
    the drawback that not all PKI implementations support policy
    certificates.
 
-9.2.1.5.  Policy constraints in a cross-certificate
+8.3.1.5.  Policy constraints in a cross-certificate
 
    This method behaves similarly to the policy certificate method above,
    but has better support across PKI implementations.
 
-9.2.1.6.  Revoked Algorithms CRL Extension
+8.3.1.6.  Revoked Algorithms CRL Extension
 
    Add an extension to CRLs so that in addition to revoking
    certificates, they can also revoke algorithms for all certificates
@@ -826,6 +945,15 @@ Internet-Draft             PQ Composite Certs                   May 2019
    There may only be one "RevokedAlgorithms" extension in a CRL.  This
    extension is OPTIONAL.  If a CRL contains only composite
    certificates, then this extension SHOULD be designated as critical.
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 17]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    If a CRL contains a mixture of composite and traditional certificates
    then it SHOULD be designated as non-critical.
 
@@ -833,15 +961,6 @@ Internet-Draft             PQ Composite Certs                   May 2019
    client performing a certificate validation on an otherwise non-
    revoked certificate within the scope of that CRL MUST skip any
    signatures corresponding to a revoked algorithm; thus a certificate
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 15]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
    is valid only if it would have been valid had those Algorithm IDs and
    Signature Values been omitted from the certificate.
 
@@ -865,7 +984,7 @@ Internet-Draft             PQ Composite Certs                   May 2019
    mechanisms (this does not apply when the algorithm is globally
    revoked for the entire scope of this CRL).
 
-9.2.1.6.1.  Implicit Revocation
+8.3.1.6.1.  Implicit Revocation
 
    A Composite Signature Algorithm is considered to be "implicitly
    revoked" if the certificate is otherwise valid but one of the
@@ -882,23 +1001,22 @@ Internet-Draft             PQ Composite Certs                   May 2019
       performed by a compliant client, regardless of which verification
       algorithm is used.
 
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 18]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    At the time of an algorithm revocation, a certificate authority MAY
    revoke certificates meeting one ofd the above criteria (by placing
    them in the traditional "revokedCertificates" list) with a revocation
    reason of "keyCompromise".  OCSP responders SHOULD designate a
    certificate as revoked if it meets the above condition.
 
-
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 16]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
-
-10.  Contributors and Acknowledgements
+9.  Contributors and Acknowledgements
 
    This document incorporates contributions and comments from a large
    group of experts.  The Editors would especially like to acknowledge
@@ -917,9 +1035,9 @@ Internet-Draft             PQ Composite Certs                   May 2019
    "Copying always makes things easier and less error prone" -
    [RFC8411].
 
-11.  References
+10.  References
 
-11.1.  Normative References
+10.1.  Normative References
 
    [RFC1421]  Linn, J., "Privacy Enhancement for Internet Electronic
               Mail: Part I: Message Encryption and Authentication
@@ -936,6 +1054,18 @@ Internet-Draft             PQ Composite Certs                   May 2019
               DOI 10.17487/RFC2986, November 2000,
               <https://www.rfc-editor.org/info/rfc2986>.
 
+
+
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 19]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    [RFC4210]  Adams, C., Farrell, S., Kause, T., and T. Mononen,
               "Internet X.509 Public Key Infrastructure Certificate
               Management Protocol (CMP)", RFC 4210,
@@ -945,14 +1075,6 @@ Internet-Draft             PQ Composite Certs                   May 2019
    [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
               Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
               <https://www.rfc-editor.org/info/rfc4648>.
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 17]
-
-Internet-Draft             PQ Composite Certs                   May 2019
-
 
    [RFC5280]  Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
               Housley, R., and W. Polk, "Internet X.509 Public Key
@@ -977,7 +1099,7 @@ Internet-Draft             PQ Composite Certs                   May 2019
               RFC 8411, DOI 10.17487/RFC8411, August 2018,
               <https://www.rfc-editor.org/info/rfc8411>.
 
-11.2.  Informative References
+10.2.  Informative References
 
    [I-D.pala-composite-crypto]
               Pala, M., "Composite Public Keys and Signatures", draft-
@@ -990,6 +1112,16 @@ Internet-Draft             PQ Composite Certs                   May 2019
               Algorithm X.509 Certificates", draft-truskovsky-lamps-pq-
               hybrid-x509-01 (work in progress), August 2018.
 
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 20]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
 Authors' Addresses
 
    Mike Ounsworth
@@ -999,15 +1131,6 @@ Authors' Addresses
    Canada
 
    Email: mike.ounsworth@entrustdatacard.com
-
-
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 18]
-
-Internet-Draft             PQ Composite Certs                   May 2019
 
 
    Massimiliano Pala
@@ -1050,15 +1173,4 @@ Internet-Draft             PQ Composite Certs                   May 2019
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-Ounsworth (Editor) & MaxExpiresEDecember 1, 2019               [Page 19]
+Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 21]

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -5,8 +5,8 @@
 LAMPS                                              M. Ounsworth (Editor)
 Internet-Draft                                          Entrust Datacard
 Intended status: Standards Track                        M. Pala (Editor)
-Expires: December 7, 2019                                      CableLabs
-                                                           June 05, 2019
+Expires: December 8, 2019                                      CableLabs
+                                                           June 06, 2019
 
 
          Composite Keys and Signatures For Use In Internet PKI
@@ -46,14 +46,14 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 7, 2019.
+   This Internet-Draft will expire on December 8, 2019.
 
 
 
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 1]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 1]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -82,43 +82,44 @@ Table of Contents
      2.1.  Algorithm Identifier  . . . . . . . . . . . . . . . . . .   5
      2.2.  Composite Keys  . . . . . . . . . . . . . . . . . . . . .   5
      2.3.  Composite Public Key  . . . . . . . . . . . . . . . . . .   6
-     2.4.  Composite Private Key . . . . . . . . . . . . . . . . . .   6
-       2.4.1.  Encrypted and Un-encrypted Local Storage  . . . . . .   7
-       2.4.2.  Asymmetric Key Packages . . . . . . . . . . . . . . .   7
-     2.5.  Composite Signature Algorithm . . . . . . . . . . . . . .   8
-     2.6.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   9
-   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .   9
-     3.1.  Composite Signature Generation  . . . . . . . . . . . . .   9
+     2.4.  Key Usage Bits  . . . . . . . . . . . . . . . . . . . . .   6
+     2.5.  Composite Private Key . . . . . . . . . . . . . . . . . .   7
+       2.5.1.  Encrypted and Un-encrypted Local Storage  . . . . . .   7
+       2.5.2.  Asymmetric Key Packages . . . . . . . . . . . . . . .   8
+     2.6.  Composite Signature Algorithm . . . . . . . . . . . . . .   8
+     2.7.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   9
+   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .  10
+     3.1.  Composite Signature Generation  . . . . . . . . . . . . .  10
      3.2.  Composite Signature Verification  . . . . . . . . . . . .  10
-   4.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  12
-   5.  Implications for existing standards . . . . . . . . . . . . .  12
-     5.1.  RFC 2986  . . . . . . . . . . . . . . . . . . . . . . . .  12
-     5.2.  RFC 5280  . . . . . . . . . . . . . . . . . . . . . . . .  12
-     5.3.  Cryptographic protocols . . . . . . . . . . . . . . . . .  12
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
-     7.1.  Protection of Private Keys  . . . . . . . . . . . . . . .  13
-     7.2.  Checking for Compromised Key Reuse  . . . . . . . . . . .  13
-     7.3.  Composite Encryption and KEMs . . . . . . . . . . . . . .  13
-   8.  Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     8.1.  ASN.1 Module  . . . . . . . . . . . . . . . . . . . . . .  14
-     8.2.  Intellectual Property Considerations  . . . . . . . . . .  15
-     8.3.  Other ideas that were considered  . . . . . . . . . . . .  15
+   4.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  13
+   5.  Implications for existing standards . . . . . . . . . . . . .  13
+     5.1.  RFC 2986  . . . . . . . . . . . . . . . . . . . . . . . .  13
+     5.2.  RFC 5280  . . . . . . . . . . . . . . . . . . . . . . . .  13
+     5.3.  Cryptographic protocols . . . . . . . . . . . . . . . . .  13
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
+     7.1.  Protection of Private Keys  . . . . . . . . . . . . . . .  14
+     7.2.  Checking for Compromised Key Reuse  . . . . . . . . . . .  14
+     7.3.  Composite Encryption and KEMs . . . . . . . . . . . . . .  14
+   8.  Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     8.1.  ASN.1 Module  . . . . . . . . . . . . . . . . . . . . . .  15
+     8.2.  Intellectual Property Considerations  . . . . . . . . . .  16
+     8.3.  Other ideas that were considered  . . . . . . . . . . . .  16
        8.3.1.  Mechanisms to distribute verification policy to
-               clients . . . . . . . . . . . . . . . . . . . . . . .  15
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 2]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 2]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
-   9.  Contributors and Acknowledgements . . . . . . . . . . . . . .  19
-   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  19
-     10.1.  Normative References . . . . . . . . . . . . . . . . . .  19
-     10.2.  Informative References . . . . . . . . . . . . . . . . .  20
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  21
+               clients . . . . . . . . . . . . . . . . . . . . . . .  16
+   9.  Contributors and Acknowledgements . . . . . . . . . . . . . .  20
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  20
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  20
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  21
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  22
 
 1.  Introduction
 
@@ -161,15 +162,15 @@ Internet-Draft             PQ Composite Certs                  June 2019
    _EDNOTE: While the scope of this document is restricted to
    signatures, we note that the same structure is equally applicable to
    asymmetric encryption keys.  Though a word of warning that the
-   corresponding "encrypt / decrypt with a composite public key" logic
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 3]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 3]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+   corresponding "encrypt / decrypt with a composite public key" logic
    is somewhat less obvious; a naive implementer might be tempted to
    follow the same pattern as below and encrypt the message with each
    public key separately and then concatenate the ciphertexts, which is
@@ -220,8 +221,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 4]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 4]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -277,7 +277,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 5]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 5]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -300,16 +300,61 @@ Internet-Draft             PQ Composite Certs                  June 2019
    component public key.
 
    Each element of a CompositePublicKey is a SubjectPublicKeyInfo object
-   for a component public key.  When the composite public key must be
+   for a component public key.  When the CompositePublicKey must be
    provided in octet string or bit string format, the data structure is
-   converted as specified in Section 2.6.
+   converted as specified in Section 2.7.
 
    The composite public key data is represented by the following
    structure:
 
    CompositePublicKey ::= SEQUENCE SIZE (1..MAX) OF SubjectPublicKeyInfo
 
-2.4.  Composite Private Key
+2.4.  Key Usage Bits
+
+   The intended application for the key is indicated in the keyUsage
+   certificate extension and defined in the CERT-KEY-USAGE field of pk-
+   Composite.
+
+   If the keyUsage extension is present in an end-entity certificate
+   that indicates id-Composite, then the keyUsage extension MUST contain
+   one or both of the following values:
+
+       nonRepudiation; and
+       digitalSignature.
+
+   If the keyUsage extension is present in a certification authority
+   certificate that indicates id-Composite, then the keyUsage extension
+   MUST contain one or more of the following values:
+
+       nonRepudiation;
+       digitalSignature;
+       keyCertSign; and
+       cRLSign.
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 6]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
+   _EDNOTE: BEGIN - This text is based on RFC 8410 (Ed25519 etc in
+   X.509).  It specifies a minimum required set of key usage bits to
+   set, but doesn't preclude one from setting more.  On the other hand,
+   the text for cms-hash-sig is below.  It is less explicit about which
+   situations use the signature-related bits, but does preclude all
+   other bits from being set.  Do we want to follow one or the other of
+   these models?
+
+   QUOTE: When this AlgorithmIdentifier appears in the
+   SubjectPublicKeyInfo field of an X.509 certificate [RFC5280], the
+   certificate key usage extension MAY contain digitalSignature,
+   nonRepudiation, keyCertSign, and cRLSign; however, it MUST NOT
+   contain other values.
+
+   _EDNOTE: END
+
+2.5.  Composite Private Key
 
    A composite private key is a sequence of component private keys that
    are used together.  The AlgorithmIdentifier for a composite private
@@ -325,22 +370,9 @@ Internet-Draft             PQ Composite Certs                  June 2019
    The composite private key data is represented by the following
    structure:
 
-   TODO: the previous version defined the CompositePrivateKey as a
-   SEQUENCE of OneAsymmetricKey but also said that it is a SEQUENCE of
-   BIT STRINGs.  This doesn't make sense unless the OneAsymmetricKey
-   objects are wrapped as a BIT STRING (in which case we need to specify
-   this and why).
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 6]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
    CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
 
-2.4.1.  Encrypted and Un-encrypted Local Storage
+2.5.1.  Encrypted and Un-encrypted Local Storage
 
    The compositePrivateKey format as defined in the previous subsection
    can also be used for local storage of an unencrypted
@@ -352,6 +384,15 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    -----BEGIN COMPOSITE PRIVATE KEY-----
    -----END COMPOSITE PRIVATE KEY-----
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 7]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    Local storage of an encrypted CompositePrivateKeys object is out of
    scope of this document.  However, CompositePrivateKey should be the
@@ -365,7 +406,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
    -----BEGIN ENCRYPTED COMPOSITE PRIVATE KEY-----
    -----END ENCRYPTED COMPOSITE PRIVATE KEY-----
 
-2.4.2.  Asymmetric Key Packages
+2.5.2.  Asymmetric Key Packages
 
    The Cryptographic Message Syntax (CMS), as defined in [RFC5652], can
    be used to digitally sign, digest, authenticate, or encrypt the
@@ -385,15 +426,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    sequence SHALL be the same as identified in the sequence of
    parameters in the privateKeyAlgorithm.
 
-
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 7]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
    The value of the the publicKey (if present) SHALL be set to the DER
    encoding of the SEQUENCE of publicKey values.  If this field is
    present, the number and order of elements SHALL be the same as
@@ -401,9 +433,22 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    The value of the attributes is encoded as usual.
 
-2.5.  Composite Signature Algorithm
+2.6.  Composite Signature Algorithm
 
    The ASN.1 algorithm object for a composite signature is:
+
+
+
+
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 8]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
        IDENTIFIER id-Composite
@@ -441,16 +486,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
    contain signatures by the same component algorithms listed in the
    same order as in the associated "CompositeParams".
 
-
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 8]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
-2.6.  Encoding Rules
+2.7.  Encoding Rules
 
    Many specifications require that the composite public key and
    composite signature data structures be represented by an octet string
@@ -462,6 +498,14 @@ Internet-Draft             PQ Composite Certs                  June 2019
    When a bit string is required, the octets of the DER encoded
    composite data structure SHALL be used as the bits of the bit string,
    with the most significant bit of the first octet becoming the first
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 9]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    bit, and so on, ending with the least significant bit of the last
    octet becoming the last bit of the bit string.
 
@@ -485,26 +529,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    The following algorithm is used to generate composite signature
    values.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019                [Page 9]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
 
    Input:
         K1, K2, ..., Kn    Private keys for the n component signature
@@ -530,6 +554,14 @@ Internet-Draft             PQ Composite Certs                  June 2019
    Verification of a composite signature involves applying each
    component algorithm's verification routine according to its
    specification, and then outputting "Valid signature" (true) if a
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 10]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    sufficient number of component algorithms were valid, and "Invalid
    signature" (false) otherwise.
 
@@ -557,7 +589,31 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 10]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 11]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -613,7 +669,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 11]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 12]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -669,7 +725,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 12]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 13]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -725,7 +781,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 13]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 14]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -781,7 +837,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 14]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 15]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -837,7 +893,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 15]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 16]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -893,7 +949,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 16]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 17]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -949,7 +1005,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 17]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 18]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1005,7 +1061,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 18]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 19]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1061,7 +1117,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 19]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 20]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1117,7 +1173,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 20]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 21]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1173,4 +1229,4 @@ Authors' Addresses
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 7, 2019               [Page 21]
+Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 22]

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -80,7 +80,7 @@ Table of Contents
      1.2.  Notation  . . . . . . . . . . . . . . . . . . . . . . . .   4
    2.  Composite Structures  . . . . . . . . . . . . . . . . . . . .   5
      2.1.  Algorithm Identifier  . . . . . . . . . . . . . . . . . .   5
-     2.2.  Composite Keys  . . . . . . . . . . . . . . . . . . . . .   5
+     2.2.  Composite Keys  . . . . . . . . . . . . . . . . . . . . .   6
      2.3.  Composite Public Key  . . . . . . . . . . . . . . . . . .   6
      2.4.  Key Usage Bits  . . . . . . . . . . . . . . . . . . . . .   6
      2.5.  Composite Private Key . . . . . . . . . . . . . . . . . .   7
@@ -264,13 +264,13 @@ Internet-Draft             PQ Composite Certs                  June 2019
    private key, and a signature.  Additional encoding information is
    provided below for each of these objects.
 
- id-Composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
-     dod(6) internet(1) private(4) enterprise(1) OpenCA(18227)
-     Algorithms(2) id-alg-composite(101) }
+id-alg-composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
+    dod(6) internet(1) private(4) enterprise(1) OpenCA(18227)
+    Algorithms(2) id-alg-composite(1) }
 
-2.2.  Composite Keys
+   EDNOTE: this is a temporary OID for the purposes of prototyping.  We
+   are requesting IANA to assign a permanent OID, see section Section 6.
 
-   The ASN.1 algorithm object for composite public and private keys is:
 
 
 
@@ -282,8 +282,12 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 5]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+2.2.  Composite Keys
+
+   The ASN.1 algorithm object for composite public and private keys is:
+
    pk-Composite PUBLIC-KEY ::= {
-       IDENTIFIER id-Composite
+       IDENTIFIER id-alg-composite
        KEY CompositePublicKey
        PARAMS ARE absent
        CERT-KEY-USAGE
@@ -323,13 +327,9 @@ Internet-Draft             PQ Composite Certs                  June 2019
        digitalSignature.
 
    If the keyUsage extension is present in a certification authority
-   certificate that indicates id-Composite, then the keyUsage extension
-   MUST contain one or more of the following values:
+   certificate that indicates id-alg-composite, then the keyUsage
+   extension MUST contain one or more of the following values:
 
-       nonRepudiation;
-       digitalSignature;
-       keyCertSign; and
-       cRLSign.
 
 
 
@@ -337,6 +337,11 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 6]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
+
+       nonRepudiation;
+       digitalSignature;
+       keyCertSign; and
+       cRLSign.
 
    _EDNOTE: BEGIN - This text is based on RFC 8410 (Ed25519 etc in
    X.509).  It specifies a minimum required set of key usage bits to
@@ -358,9 +363,9 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    A composite private key is a sequence of component private keys that
    are used together.  The AlgorithmIdentifier for a composite private
-   key uses the id-Composite object identifier, and the parameters field
-   MUST be absent.  A composite private key MUST contain at least one
-   component private key.
+   key uses the id-alg-composite object identifier, and the parameters
+   field MUST be absent.  A composite private key MUST contain at least
+   one component private key.
 
    Each element of a CompositePrivateKey is a OneAsymmetricKey [RFC5958]
    object for a component private key.  The component private key's
@@ -382,17 +387,15 @@ Internet-Draft             PQ Composite Certs                  June 2019
    [RFC4648]), of the DER-encoded compositePrivateKey object with the
    following armour:
 
-   -----BEGIN COMPOSITE PRIVATE KEY-----
-   -----END COMPOSITE PRIVATE KEY-----
-
-
-
 
 
 Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 7]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
+
+   -----BEGIN COMPOSITE PRIVATE KEY-----
+   -----END COMPOSITE PRIVATE KEY-----
 
    Local storage of an encrypted CompositePrivateKeys object is out of
    scope of this document.  However, CompositePrivateKey should be the
@@ -413,7 +416,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
    asymmetric key format content type.
 
    When encoding composite private keys, the privateKeyAlgorithm in the
-   OneAsymmetricKey SHALL be set to id-Composite.
+   OneAsymmetricKey SHALL be set to id-alg-composite.
 
    The parameters of the privateKeyAlgorithm SHALL be a sequence of
    AlgorithmIdentifier objects, each of which are encoded according to
@@ -442,23 +445,20 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-
-
-
 Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 8]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
    sa-CompositeSignature SIGNATURE-ALGORITHM ::= {
-       IDENTIFIER id-Composite
+       IDENTIFIER id-alg-composite
        VALUE CompositeSignatureValue
        PARAMS TYPE CompositeParams ARE required
        PUBLIC-KEYS { pk-Composite }
        SMIME-CAPS { IDENTIFIED BY id-Composite } }
    }
 
-   The id-Composite object identifier is used to identify when a
+   The id-alg-composite object identifier is used to identify when a
    signature has been created by a composite private key.
 
    The following algorithm parameters MUST be included when this
@@ -741,12 +741,13 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 6.  IANA Considerations
 
-   The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned
-   by IANA.  The authors suggest to use the id-pkix arc for this usage:
+   The ASN.1 module OID is TBD.  The id-alg-composite OID is to be
+   assigned by IANA.  The authors suggest to use the id-pkix arc for
+   this usage:
 
-  id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
-      dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
-      id-alg-composite(??) }
+id-alg-composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+    dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
+    composite(??) }
 
 7.  Security Considerations
 
@@ -777,7 +778,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    This document deals only with signature keys.  While the
    CompositePublicKey and CompositePrivateKey structures could equally
    be used to hold encryption or KEM keys, the authors warn that there
-   are non-trivial design decisions to be made when constructing a
 
 
 
@@ -786,6 +786,7 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 14]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+   are non-trivial design decisions to be made when constructing a
    multi-key public key encryption or KEM algorithm.  Some of these
    design and implementation decisions, if done incorrectly will result
    in a catastrophic loss of security.  We leave it to the community to
@@ -833,7 +834,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    -- Public Key
    --
 
-   pk-Composite PUBLIC-KEY ::= {
 
 
 
@@ -842,6 +842,7 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 15]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+   pk-Composite PUBLIC-KEY ::= {
        IDENTIFIER id-Composite
        KEY CompositePublicKey
        PARAMS ARE absent
@@ -889,7 +890,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    This section is here to be informative during the review process, to
    document ideas that were raised and the rationales for not including
    them in the final draft.
-
 
 
 

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -84,11 +84,11 @@ Table of Contents
      2.3.  Composite Public Key  . . . . . . . . . . . . . . . . . .   6
      2.4.  Key Usage Bits  . . . . . . . . . . . . . . . . . . . . .   6
      2.5.  Composite Private Key . . . . . . . . . . . . . . . . . .   7
-     2.6.  Composite Signature Algorithm . . . . . . . . . . . . . .   8
+     2.6.  Composite Signature Algorithm . . . . . . . . . . . . . .   7
      2.7.  Encoding Rules  . . . . . . . . . . . . . . . . . . . . .   8
-   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .   9
+   3.  Composite Signature Algorithm . . . . . . . . . . . . . . . .   8
      3.1.  Composite Signature Generation  . . . . . . . . . . . . .   9
-     3.2.  Composite Signature Verification  . . . . . . . . . . . .  10
+     3.2.  Composite Signature Verification  . . . . . . . . . . . .   9
    4.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  12
      4.1.  PEM Storage of Composite Private Keys . . . . . . . . . .  12
      4.2.  Asymmetric Key Packages (CMS) . . . . . . . . . . . . . .  12
@@ -350,22 +350,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
        keyCertSign; and
        cRLSign.
 
-   _EDNOTE: BEGIN - This text is based on RFC 8410 (Ed25519 etc in
-   X.509).  It specifies a minimum required set of key usage bits to
-   set, but doesn't preclude one from setting more.  On the other hand,
-   the text for cms-hash-sig is below.  It is less explicit about which
-   situations use the signature-related bits, but does preclude all
-   other bits from being set.  Do we want to follow one or the other of
-   these models?
-
-   QUOTE: When this AlgorithmIdentifier appears in the
-   SubjectPublicKeyInfo field of an X.509 certificate [RFC5280], the
-   certificate key usage extension MAY contain digitalSignature,
-   nonRepudiation, keyCertSign, and cRLSign; however, it MUST NOT
-   contain other values.
-
-   _EDNOTE: END
-
 2.5.  Composite Private Key
 
    A composite private key is a sequence of component private keys that
@@ -384,16 +368,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    CompositePrivateKey ::= SEQUENCE SIZE (1..MAX) OF OneAsymmetricKey
 
-
-
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 7]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
 2.6.  Composite Signature Algorithm
 
    The ASN.1 algorithm object for a composite signature is:
@@ -411,6 +385,14 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
    The following algorithm parameters MUST be included when this
    identifier is used to identify a signature algorithm:
+
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 7]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    CompositeParams ::= SEQUENCE SIZE (1..MAX) OF AlgorithmIdentifier
 
@@ -443,13 +425,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    When an octet string is required, the DER encoding of the composite
    data structure SHALL be used directly.
 
-
-
-Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 8]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
    When a bit string is required, the octets of the DER encoded
    composite data structure SHALL be used as the bits of the bit string,
    with the most significant bit of the first octet becoming the first
@@ -467,6 +442,13 @@ Internet-Draft             PQ Composite Certs                  June 2019
    signature algorithms to the input message, with the resulting
    signature effectively being the concatenation of the individual
    signature values.
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 8]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
 
    This algorithm addresses algorithm strength uncertainty by providing
    the verifier with parallel signatures from all the component
@@ -498,14 +480,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
         Let S be the DER encoding of the Signature
       3. Output S
 
-
-
-
-Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 9]
-
-Internet-Draft             PQ Composite Certs                  June 2019
-
-
    Since recursive composite public keys are disallowed in section
    Section 2.3, no component signature may itself be composite; ie the
    signature generation routine MUST fail if one of the private keys K1,
@@ -524,6 +498,14 @@ Internet-Draft             PQ Composite Certs                  June 2019
    implementations SHOULD include a field-updatable policy mechanism for
    determining which and/or how many component algorithms must be valid
    in order for the composite signature as a whole to be considered
+
+
+
+Ounsworth (Editor) & PalExpiresoDecember 15, 2019               [Page 9]
+
+Internet-Draft             PQ Composite Certs                  June 2019
+
+
    valid.  This section assumes the existence of such a policy
    mechanism, denoted as "checkPolicy(A1, A2, ..., An)" in the algorithm
    below.  The implementation of such a policy mechanism is the
@@ -538,6 +520,24 @@ Internet-Draft             PQ Composite Certs                  June 2019
    signatures.  Compliant implementations MUST return "Invalid
    signature" whenever the sample algorithm does, with the exception of
    the modification noted below.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -5,8 +5,8 @@
 LAMPS                                              M. Ounsworth (Editor)
 Internet-Draft                                          Entrust Datacard
 Intended status: Standards Track                        M. Pala (Editor)
-Expires: December 8, 2019                                      CableLabs
-                                                           June 06, 2019
+Expires: December 13, 2019                                     CableLabs
+                                                           June 11, 2019
 
 
          Composite Keys and Signatures For Use In Internet PKI
@@ -46,14 +46,14 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 8, 2019.
+   This Internet-Draft will expire on December 13, 2019.
 
 
 
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 1]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 1]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 2]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 2]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -165,7 +165,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 3]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 3]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -184,7 +184,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in BCP
-   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   14 [RFC2119]  [RFC8174] when, and only when, they appear in all
    capitals, as shown here.
 
    The following terms are used:
@@ -221,7 +221,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 4]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 4]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -264,7 +264,9 @@ Internet-Draft             PQ Composite Certs                  June 2019
    private key, and a signature.  Additional encoding information is
    provided below for each of these objects.
 
-   id-Composite OBJECT IDENTIFIER ::= { TBD }
+  id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+      dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
+      id-alg-composite(101) }
 
 2.2.  Composite Keys
 
@@ -275,9 +277,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-
-
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 5]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 5]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -333,7 +333,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 6]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 6]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -389,7 +389,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 7]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 7]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -445,7 +445,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 8]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 8]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -501,7 +501,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019                [Page 9]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 9]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -557,7 +557,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 10]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 10]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -613,7 +613,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 11]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 11]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -669,7 +669,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 12]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 12]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -725,7 +725,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 13]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 13]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -781,7 +781,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 14]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 14]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -837,7 +837,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 15]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 15]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -893,7 +893,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 16]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 16]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -949,7 +949,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 17]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 17]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1005,7 +1005,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 18]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 18]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1061,7 +1061,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 19]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 19]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1117,7 +1117,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 20]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 20]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1173,7 +1173,7 @@ Internet-Draft             PQ Composite Certs                  June 2019
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 21]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 21]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
@@ -1229,4 +1229,4 @@ Authors' Addresses
 
 
 
-Ounsworth (Editor) & PalExpiresoDecember 8, 2019               [Page 22]
+Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 22]

--- a/draft-ounsworth-pq-composite-sigs.txt
+++ b/draft-ounsworth-pq-composite-sigs.txt
@@ -114,7 +114,7 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019               [Page 2]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
-               clients . . . . . . . . . . . . . . . . . . . . . . .  16
+               clients . . . . . . . . . . . . . . . . . . . . . . .  17
    9.  Contributors and Acknowledgements . . . . . . . . . . . . . .  20
    10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  20
      10.1.  Normative References . . . . . . . . . . . . . . . . . .  20
@@ -264,9 +264,9 @@ Internet-Draft             PQ Composite Certs                  June 2019
    private key, and a signature.  Additional encoding information is
    provided below for each of these objects.
 
-  id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
-      dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
-      id-alg-composite(101) }
+ id-Composite OBJECT IDENTIFIER ::= { iso(1)  identified-organization(3)
+     dod(6) internet(1) private(4) enterprise(1) OpenCA(18227)
+     Algorithms(2) id-alg-composite(101) }
 
 2.2.  Composite Keys
 
@@ -742,7 +742,11 @@ Internet-Draft             PQ Composite Certs                  June 2019
 6.  IANA Considerations
 
    The ASN.1 module OID is TBD.  The id-Composite OID is to be assigned
-   by IANA.  The authors suggest to use the id-pkix arc for this usage.
+   by IANA.  The authors suggest to use the id-pkix arc for this usage:
+
+  id-Composite OBJECT IDENTIFIER ::= { iso(1) identified-organization(3)
+      dod(6) internet(1) security(5) mechanisms(5) pkix(7) algorithms(6)
+      id-alg-composite(??) }
 
 7.  Security Considerations
 
@@ -774,10 +778,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    CompositePublicKey and CompositePrivateKey structures could equally
    be used to hold encryption or KEM keys, the authors warn that there
    are non-trivial design decisions to be made when constructing a
-   multi-key public key encryption or KEM algorithm.  Some of these
-   design and implementation decisions, if done incorrectly will result
-   in a catastrophic loss of security.  We leave it to the community to
-   standardize analogous composite encryption and KEM schemes.
 
 
 
@@ -785,6 +785,11 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 14]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
+
+   multi-key public key encryption or KEM algorithm.  Some of these
+   design and implementation decisions, if done incorrectly will result
+   in a catastrophic loss of security.  We leave it to the community to
+   standardize analogous composite encryption and KEM schemes.
 
 8.  Appendices
 
@@ -829,11 +834,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    --
 
    pk-Composite PUBLIC-KEY ::= {
-       IDENTIFIER id-Composite
-       KEY CompositePublicKey
-       PARAMS ARE absent
-       CERT-KEY-USAGE
-           { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
 
 
 
@@ -842,6 +842,11 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 15]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+       IDENTIFIER id-Composite
+       KEY CompositePublicKey
+       PARAMS ARE absent
+       CERT-KEY-USAGE
+           { digitalSignature, nonRepudiation, keyCertSign, cRLSign }
        PRIVATE-KEY CompositePrivateKey
    }
 
@@ -885,11 +890,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
    document ideas that were raised and the rationales for not including
    them in the final draft.
 
-8.3.1.  Mechanisms to distribute verification policy to clients
-
-   EDNOTE: The authors had extensive discussions about how to handle
-   algorithm revocation / deprication, sepcifically around how to
-   distribute policy information to verifiers.  In the end we decided to
 
 
 
@@ -898,6 +898,11 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 16]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+8.3.1.  Mechanisms to distribute verification policy to clients
+
+   EDNOTE: The authors had extensive discussions about how to handle
+   algorithm revocation / deprication, sepcifically around how to
+   distribute policy information to verifiers.  In the end we decided to
    remove the whole thing and instead leave this is a responsibility of
    the implementors of the software performing signature verification.
 
@@ -939,13 +944,8 @@ Internet-Draft             PQ Composite Certs                  June 2019
    software vendors to implement the guidance of governing bodies on a
    system-by-system basis.
 
-8.3.1.2.  Extra metadata in the public key or signature
 
-   This policy information could be specified by the signer at signing
-   time.  Depending on the structure of the databeing signed, this
-   metadata could go into the public key, or an extension to the
-   signature, or some other field provided that it is inside the signed
-   data blob.
+
 
 
 
@@ -953,6 +953,14 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 17]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
+
+8.3.1.2.  Extra metadata in the public key or signature
+
+   This policy information could be specified by the signer at signing
+   time.  Depending on the structure of the databeing signed, this
+   metadata could go into the public key, or an extension to the
+   signature, or some other field provided that it is inside the signed
+   data blob.
 
 8.3.1.3.  Extra metadata in the certificate
 
@@ -994,14 +1002,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
                                  -- if present, version MUST be v2
         }
 
-   _EDNOTE: do we need the crlEntryExtensions field?  If so, which ones
-   from https://tools.ietf.org/html/rfc5280#section-5.3 are allowed
-   here?_
-
-   There may only be one "RevokedAlgorithms" extension in a CRL.  This
-   extension is OPTIONAL.  If a CRL contains only composite
-   certificates, then this extension SHOULD be designated as critical.
-
 
 
 
@@ -1010,6 +1010,13 @@ Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 18]
 Internet-Draft             PQ Composite Certs                  June 2019
 
 
+   _EDNOTE: do we need the crlEntryExtensions field?  If so, which ones
+   from https://tools.ietf.org/html/rfc5280#section-5.3 are allowed
+   here?_
+
+   There may only be one "RevokedAlgorithms" extension in a CRL.  This
+   extension is OPTIONAL.  If a CRL contains only composite
+   certificates, then this extension SHOULD be designated as critical.
    If a CRL contains a mixture of composite and traditional certificates
    then it SHOULD be designated as non-critical.
 
@@ -1052,19 +1059,17 @@ Internet-Draft             PQ Composite Certs                  June 2019
       succeed when performed by a legacy client which is not aware of
       this CRL extension.
 
-   o  All of the component algorithms are revoked within the scope if
-      its CRL.  In this case, signature verification MUST fail when
-      performed by a compliant client, regardless of which verification
-      algorithm is used.
-
-
-
 
 
 Ounsworth (Editor) & PalExpiresoDecember 13, 2019              [Page 19]
 
 Internet-Draft             PQ Composite Certs                  June 2019
 
+
+   o  All of the component algorithms are revoked within the scope if
+      its CRL.  In this case, signature verification MUST fail when
+      performed by a compliant client, regardless of which verification
+      algorithm is used.
 
    At the time of an algorithm revocation, a certificate authority MAY
    revoke certificates meeting one ofd the above criteria (by placing
@@ -1109,11 +1114,6 @@ Internet-Draft             PQ Composite Certs                  June 2019
               Request Syntax Specification Version 1.7", RFC 2986,
               DOI 10.17487/RFC2986, November 2000,
               <https://www.rfc-editor.org/info/rfc2986>.
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Separate OIDs are only necessary for keys and signature algorithms
when the signature algorithm can be combined with a pre-hash (e.g.
ecdsa-with-sha256).  This doesn't apply to composite signatures
since the pre-hash will be specific to each of the component
algorithms.

This change also uses the SIGNATURE-ALGORITHM and PUBLIC-KEY object
types of RFC 5912.

Closes #50